### PR TITLE
Use a lightweight hashing function by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ outplan.create("letter-experiment", ["A", "B"], {
 });
 ```
 
-OutPlan is doesn't use SHA1 and BigNumbers by default in order to keep a light
-footprint, particularly when used in the client. To use the full SHA1
-implementation for deterministic hashes as used by PlanOut, use the following:
+OutPlan uses MD5 for hashing. The underlying Planout.js library can also
+use SHA1, but it's a bit more heavy-weight for client-side applications.
+If you want to use SHA1, try the following:
 
 ```
 var outplan = require("outplan/dist/outplan_full");

--- a/README.md
+++ b/README.md
@@ -57,18 +57,6 @@ outplan.create("letter-experiment", ["A", "B"], {
 });
 ```
 
-OutPlan uses MD5 for hashing. The underlying Planout.js library can also
-use SHA1, but it's a bit more heavy-weight for client-side applications.
-If you want to use SHA1, try the following:
-
-```
-var outplan = require("outplan/dist/outplan_full");
-
-// optionally, use BigNumber for hashes compatible with non-JS implementations
-outplan.configure({ compatibleHash: true });
-```
-
-
 ### Logging
 
 You can set an event logger using 
@@ -116,6 +104,19 @@ function log(e) {
     ga("send", "event", "EXPERIMENT", label, e.params.name);
 }
 outplan.configure({ logFunction: log });
+```
+
+## Hashing Algorithm
+
+OutPlan uses MD5 for hashing. The underlying Planout.js library can also
+use SHA1, but it's a bit more heavy-weight for client-side applications.
+If you want to use SHA1, try the following:
+
+```javascript
+var outplan = require("outplan/dist/outplan_full");
+
+// For compatibility with non-JS implementations of PlanOut (even slower):
+outplan.configure({ compatibleHash: true });
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ outplan.create("letter-experiment", ["A", "B"], {
 });
 ```
 
+OutPlan is doesn't use SHA1 and BigNumbers by default in order to keep a light
+footprint, particularly when used in the client. To use the full SHA1
+implementation for deterministic hashes as used by PlanOut, use the following:
+
+```
+var outplan = require("outplan/dist/outplan_full");
+
+// optionally, use BigNumber for hashes compatible with non-JS implementations
+outplan.configure({ compatibleHash: true });
+```
+
+
 ### Logging
 
 You can set an event logger using 

--- a/lib/outplan.js
+++ b/lib/outplan.js
@@ -31,6 +31,7 @@ module.exports.configure = function(options) {
         compatibleHash = options.compatibleHash;
     }
     salt = options.salt || String(salt);
+    sha1.$salt = options.alt || String(salt);
     return this;
 };
 

--- a/lib/outplan.js
+++ b/lib/outplan.js
@@ -1,4 +1,5 @@
 var planout = require("planout/index");
+var sha1 = require("sha1");
 
 var salt = "salt";
 var experiments = Object.create(null);
@@ -24,8 +25,11 @@ module.exports.RandomFloat = planout.Ops.Random.RandomFloat;
 module.exports.configure = function(options) {
     logFunction = options.logFunction || logFunction;
     experiments = options.experiments || experiments;
-    if (options.compatibleHash != null)
+    if (options.compatibleHash != null) {
+        if (options.compatibleHash && sha1.$shimmed)
+            throw new Error("compatibleHash is only supported in planout_full");
         compatibleHash = options.compatibleHash;
+    }
     salt = options.salt || String(salt);
     return this;
 };

--- a/lib/shims/bignumber.js
+++ b/lib/shims/bignumber.js
@@ -1,0 +1,3 @@
+module.exports = function() {};
+
+module.exports.default = function() {};

--- a/lib/shims/sha1.js
+++ b/lib/shims/sha1.js
@@ -1,0 +1,7 @@
+var hash = require("string-hash");
+
+module.exports = function(text) {
+    return String(hash(text));
+};
+
+module.exports.$shimmed = true;

--- a/lib/shims/sha1.js
+++ b/lib/shims/sha1.js
@@ -1,7 +1,7 @@
 var hash = require("string-hash");
 
 module.exports = function(text) {
-    return String(hash(text));
+    return String(hash(text + "salt"));
 };
 
 module.exports.$shimmed = true;

--- a/lib/shims/sha1.js
+++ b/lib/shims/sha1.js
@@ -1,7 +1,9 @@
-var hash = require("string-hash");
+var hash = require("md5");
 
 module.exports = function(text) {
-    return String(hash(text + "salt"));
+    return hash(text + this.$salt);
 };
+
+module.exports.$salt = "salt";
 
 module.exports.$shimmed = true;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "planout": "~2.0.2",
-    "sha1": "^1.1.1"
+    "sha1": "^1.1.1",
+    "string-hash": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outplan",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "A simple A/B testing framework based on PlanOut",
   "main": "dist/outplan.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "webpack": "^1.13.0"
   },
   "dependencies": {
+    "md5": "^2.1.0",
     "planout": "~2.0.2",
-    "sha1": "^1.1.1",
-    "string-hash": "^1.1.0"
+    "sha1": "^1.1.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,148 +1,203 @@
-var outplan = require("./dist/outplan");
+var outplanFull = require("./dist/outplan_full");
+var outplanLite = require("./dist/outplan");
 var assert = require("assert");
+
+function testBoth(test) {
+    test(outplanFull);
+    test(outplanLite);
+}
 
 describe("outplan", function() {
     this.timeout(15000);
     
     beforeEach(function() {
-        outplan.configure({
-            logFunction: function() {},
-            experiments: [],
-            compatibleHash: false,
+        testBoth(function(outplan) {
+            outplan.configure({
+                logFunction: function() {},
+                experiments: [],
+                compatibleHash: false,
+            });
         });
     });
     
     it("can create simple experiments", function() {
-        outplan.create("foo", ["A", "B"]);
-        assert.equal(Object.keys(outplan.getExperiments()).length, 1);
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"]);
+            assert.equal(Object.keys(outplan.getExperiments()).length, 1);
+        });
     });
     
     it("can create simple experiments with a custom distribution operator", function() {
-        outplan.create("foo", ["A", "B"], {
-            operator: outplan.WeightedChoice,
-            weights: [0.5, 0.5],
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"], {
+                operator: outplan.WeightedChoice,
+                weights: [0.5, 0.5],
+            });
+            assert.equal(Object.keys(outplan.getExperiments()).length, 1);
         });
-        assert.equal(Object.keys(outplan.getExperiments()).length, 1);
     });
     
     it("can create multiple experiments", function() {
-        outplan.create("foo", ["A", "B"]);
-        outplan.create("bar", ["C", "D"]);
-        assert.equal(Object.keys(outplan.getExperiments()).length, 2);
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"]);
+            outplan.create("bar", ["C", "D"]);
+            assert.equal(Object.keys(outplan.getExperiments()).length, 2);
+        });
     });
     
     it("can get values for experiments", function() {
-        outplan.create("foo", ["A", "B"]);
-        var value = outplan.expose("foo", 1);
-        assert(value === "A" || value === "B", value);
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"]);
+            var value = outplan.expose("foo", 1);
+            assert(value === "A" || value === "B", value);
+        });
     });
     
-    it("deterministically gets values", function() {
-        outplan.create("foo", ["A", "B"]);
-        assert.equal(outplan.expose("foo", 1), "B");
-        assert.equal(outplan.expose("foo", 2), "B");
-        assert.equal(outplan.expose("foo", 3), "A");
-        assert.equal(outplan.expose("foo", 4), "B");
-        assert.equal(outplan.expose("foo", "1"), "B");
-        assert.equal(outplan.expose("foo", "2"), "B");
-        assert.equal(outplan.expose("foo", "3"), "A");
-        assert.equal(outplan.expose("foo", "4"), "B");
-        assert.equal(outplan.expose("foo", "5"), "B");
-        assert.equal(outplan.expose("foo", "6"), "A");
-        assert.equal(outplan.expose("foo", "7"), "A");
-        assert.equal(outplan.expose("foo", "8"), "B");
-        assert.equal(outplan.expose("foo", "9"), "A");
+    it("deterministically gets values in outplan_full", function() {
+        outplanFull.create("foo", ["A", "B"]);
+        assert.equal(outplanFull.expose("foo", 1), "B");
+        assert.equal(outplanFull.expose("foo", 2), "B");
+        assert.equal(outplanFull.expose("foo", 3), "A");
+        assert.equal(outplanFull.expose("foo", 4), "B");
+        assert.equal(outplanFull.expose("foo", "1"), "B");
+        assert.equal(outplanFull.expose("foo", "2"), "B");
+        assert.equal(outplanFull.expose("foo", "3"), "A");
+        assert.equal(outplanFull.expose("foo", "4"), "B");
+        assert.equal(outplanFull.expose("foo", "5"), "B");
+        assert.equal(outplanFull.expose("foo", "6"), "A");
+        assert.equal(outplanFull.expose("foo", "7"), "A");
+        assert.equal(outplanFull.expose("foo", "8"), "B");
+        assert.equal(outplanFull.expose("foo", "9"), "A");
+    });
+    
+    it("deterministically gets values in lite version", function() {
+        outplanLite.create("foo", ["A", "B"]);
+        assert.equal(outplanLite.expose("foo", 1), "A");
+        assert.equal(outplanLite.expose("foo", 2), "B");
+        assert.equal(outplanLite.expose("foo", 3), "A");
+        assert.equal(outplanLite.expose("foo", 4), "B");
+        assert.equal(outplanLite.expose("foo", "1"), "A");
+        assert.equal(outplanLite.expose("foo", "2"), "B");
+        assert.equal(outplanLite.expose("foo", "3"), "A");
+        assert.equal(outplanLite.expose("foo", "4"), "B");
+        assert.equal(outplanLite.expose("foo", "5"), "A");
+        assert.equal(outplanLite.expose("foo", "6"), "B");
+        assert.equal(outplanLite.expose("foo", "7"), "A");
+        assert.equal(outplanLite.expose("foo", "8"), "B");
+        assert.equal(outplanLite.expose("foo", "9"), "A");
     });
     
     it("supports complex choice objects", function() {
+        var outplan = outplanFull;
         outplan.create("foo", [{ name: "A", color: "#AAA" }, { name: "B", color: "#BBB" }]);
         var value = outplan.expose("foo", 1);
         assert.equal(value.color, "#BBB");
     });
     
     it("can run some example code", function() {
-        outplan.create("nice-colors", [
-            { name: "A", button_color: "#AAA", button_text: "I voted" },
-            { name: "B", button_color: "#BBB", button_text: "I am voter" }
-        ]);
-        var variation = outplan.expose("nice-colors", 42);
-        var color = variation.button_color;
-        var text = variation.button_text;
-        
-        assert.equal(color, "#BBB");
-        assert.equal(text, "I am voter");
+        testBoth(function(outplan) {
+            outplan.create("nice-colors", [
+                { name: "A", button_color: "#AAA", button_text: "I voted" },
+                { name: "B", button_color: "#BBB", button_text: "I am voter" }
+            ]);
+            var variation = outplan.expose("nice-colors", 42);
+            var color = variation.button_color;
+            var text = variation.button_text;
+            
+            assert.equal(color, "#BBB");
+            assert.equal(text, "I am voter");
+        });
     });
     
     it("supports logging", function() {
-        var logged;
-        outplan.configure({
-            logFunction: function(e) {
-                logged = e;
-            }
+        testBoth(function(outplan) {
+            var logged;
+            outplan.configure({
+                logFunction: function(e) {
+                    logged = e;
+                }
+            });
+            outplan.create("foo", ["A", "B"]);
+            outplan.expose("foo", 42);
+            assert(logged, "Needs to log exposures");
+            assert.equal(logged.name, "foo");
+            assert.equal(logged.inputs.userId, 42);
+            assert.equal(logged.params.name, "B");
+            assert.equal(logged.params.value, "B");
+            assert.equal(logged.event, "exposure");
+            assert.equal(logged.salt, "salt");
+            assert(logged.time);
         });
-        outplan.create("foo", ["A", "B"]);
-        outplan.expose("foo", 42);
-        assert(logged, "Needs to log exposures");
-        assert.equal(logged.name, "foo");
-        assert.equal(logged.inputs.userId, 42);
-        assert.equal(logged.params.name, "B");
-        assert.equal(logged.params.value, "B");
-        assert.equal(logged.event, "exposure");
-        assert.equal(logged.salt, "salt");
-        assert(logged.time);
     });
     
     it("doesn't log when using { log: false }", function() {
-        var logged;
-        outplan.configure({
-            logFunction: function(e) {
-                logged = e;
-            }
+        testBoth(function(outplan) {
+            var logged;
+            outplan.configure({
+                logFunction: function(e) {
+                    logged = e;
+                }
+            });
+            outplan.create("foo", ["A", "B"]);
+            outplan.expose("foo", 42, { log: false });
+            assert(!logged);
+            outplan.expose("foo", 42, { log: true });
+            assert(logged);
         });
-        outplan.create("foo", ["A", "B"]);
-        outplan.expose("foo", 42, { log: false });
-        assert(!logged);
-        outplan.expose("foo", 42, { log: true });
-        assert(logged);
     });
     
-    it("supports compatibleHash", function() {
-        outplan.create("foo", ["A", "B"]);
-        assert.equal(outplan.expose("foo", 99), "A");
-        outplan.configure({ compatibleHash: true });
-        assert.equal(outplan.expose("foo", 99), "B");
+    it("supports compatibleHash in outplan_full", function() {
+        outplanFull.create("foo", ["A", "B"]);
+        assert.equal(outplanFull.expose("foo", 99), "A");
+        outplanFull.configure({ compatibleHash: true });
+        assert.equal(outplanFull.expose("foo", 99), "B");
+    });
+    
+    it("doesn't support compatibleHash with regular outplan", function() {
+        try {
+            outplanLite.configure({ compatibleHash: true });
+        } catch (e) {
+            return;
+        }
+        assert(false, "Exception expected");
     });
     
     it("supports a falsy userId", function() {
-        outplan.create("foo", ["A", "B"]);
-        assert.equal(outplan.expose("foo", 0), "B");
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"]);
+            assert.equal(outplan.expose("foo", 0), "B");
+        });
     });
     
     it("supports a string userId", function() {
-        outplan.create("foo", ["A", "B"]);
-        assert.equal(outplan.expose("foo", "usertje"), "A");
+        outplanFull.create("foo", ["A", "B"]);
+        assert.equal(outplanFull.expose("foo", "usertje"), "A");
     });
     
     it("supports uses the experiment name for determinism", function() {
-        outplan.create("foo", ["A", "B"]);
-        outplan.create("bar", ["A", "B"]);
-        assert.equal(outplan.expose("foo", 42), "B");
-        assert.equal(outplan.expose("bar", 42), "A");
+        outplanFull.create("foo", ["A", "B"]);
+        outplanFull.create("bar", ["A", "B"]);
+        assert.equal(outplanFull.expose("foo", 42), "B");
+        assert.equal(outplanFull.expose("bar", 42), "A");
     });
     
     it("using create multiple times doesn't affect determinism", function() {
-        outplan.create("foo", ["A", "B"]);
-        outplan.create("bar", ["A", "B"]);
-        outplan.create("foo", ["A", "B"]);
-        outplan.create("bar", ["A", "B"]);
-        assert.equal(outplan.expose("foo", 42), "B");
-        assert.equal(outplan.expose("bar", 42), "A");
+        testBoth(function(outplan) {
+            outplan.create("foo", ["A", "B"]);
+            outplan.create("bar", ["A", "B"]);
+            outplan.create("foo", ["A", "B"]);
+            outplan.create("bar", ["A", "B"]);
+            assert.equal(outplan.expose("foo", 42), "B");
+            assert.equal(outplan.expose("bar", 42), "A");
+        });
     });
     
     it("supports chaining API", function() {
-        var variation = outplan
-            .create("foo", ["A", "B"])
-            .expose(42);
-        assert.equal(variation, "B");
+        testBoth(function(outplan) {
+            var variation = outplan
+                .create("foo", ["A", "B"])
+                .expose(42);
+            assert.equal(variation, "B");
+        });
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,22 +1,52 @@
-module.exports = {
-    entry: "./lib/outplan.js",
-    output: {
-        path: __dirname,
-        filename: "dist/outplan.js",
-        libraryTarget: "umd",
-    },
-    module: {
-        loaders: [
-            {
-                loader: "babel-loader",
-                test: /planout/,
-                exclude: /planout\/node_modules/,
-                query: {
-                    presets: ["es2015"],
-                    // Maintain compatibility with imports in planout (stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default)
-                    plugins: ["add-module-exports"],
+module.exports = [
+    {
+        entry: "./lib/outplan.js",
+        output: {
+            path: __dirname,
+            filename: "dist/outplan_full.js",
+            libraryTarget: "umd",
+        },
+        module: {
+            loaders: [
+                {
+                    loader: "babel-loader",
+                    test: /planout/,
+                    exclude: /planout\/node_modules/,
+                    query: {
+                        presets: ["es2015"],
+                        // Maintain compatibility with imports in planout (stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default)
+                        plugins: ["add-module-exports"],
+                    }
                 }
+            ]
+        }
+    },
+    {
+        entry: "./lib/outplan.js",
+        output: {
+            path: __dirname,
+            filename: "dist/outplan.js",
+            libraryTarget: "umd",
+        },
+        resolve: {
+            alias: {
+                "sha1": __dirname + "/lib/shims/sha1.js",
+                "bignumber.js": __dirname + "/lib/shims/bignumber.js",
             }
-        ]
+        },
+        module: {
+            loaders: [
+                {
+                    loader: "babel-loader",
+                    test: /planout/,
+                    exclude: /planout\/node_modules/,
+                    query: {
+                        presets: ["es2015"],
+                        // Maintain compatibility with imports in planout (stackoverflow.com/questions/33505992/babel-6-changes-how-it-exports-default)
+                        plugins: ["add-module-exports"],
+                    }
+                }
+            ]
+        }
     }
-};
+];


### PR DESCRIPTION
@fjakobs I reduced the footprint of outplan in master, and I've been looking into an alternative hashing implementation that is more light-weight.

```
$ ls -l dist
total 332
-rw-r--r-- 1 ubuntu ubuntu  87342 Apr 19 13:58 outplan.js
-rw-r--r-- 1 ubuntu ubuntu 245897 Apr 19 13:53 outplan_full.js
```
